### PR TITLE
[feat] add 상담사 개인정보 수정 페이지

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import AllPrograms from './pages/all_programs';
 import ProgramDetail from './pages/program_detail';
 import Signup from './pages/signup';
 import EditUserInfo from './pages/edit_userinfo_general';
+import EditUserInfoTherapist from './pages/edit_userinfo_therapist';
 import '../node_modules/@ibm/plex/css/ibm-plex-sans-kr.min.css';  
 
 const GlobalStyle = createGlobalStyle`
@@ -51,6 +52,7 @@ function App() {
           <Route path="/test" element={<Test />} />
           <Route path="/test-result" element={<TestResult />} />
           <Route path="/edit-userinfo" element={<EditUserInfo />} />
+          <Route path="/edit-userinfo-therapist" element={<EditUserInfoTherapist />} />
           <Route path='/' element={<AllPrograms />} />
           <Route path='/program/:id' element={<ProgramDetail />} />
           <Route path='/signup' element={<Signup />} />

--- a/client/src/pages/edit_userinfo_therapist.tsx
+++ b/client/src/pages/edit_userinfo_therapist.tsx
@@ -35,7 +35,7 @@ const Logo = styled.img`
 `
 
 const InnerWrapper = styled.div`
-  width: 90vw;
+  width: 80vw;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -97,7 +97,6 @@ const Input = styled.input`
     font-size: 11px;
   }
 `
-
 const Button = styled.button`
   box-shadow: rgba(0, 0, 0, 0.12) 0px 3px 8px;
 	border-radius: 10px;
@@ -129,24 +128,20 @@ const Hr = styled.hr`
 `
 
 
-const EditUserInfo = () => {
+const EditUserInfoTherapist = () => {
   return (
     <div>
       <ContentWrapper>
         <Logo src="teacup.png" />
         <InnerWrapper>
           <Title>
-            회원정보 수정 
+            회원정보
           </Title>
           <Grid>
             <Label>회원 유형</Label>
-            <Text>일반 회원</Text>
+            <Text>상담사</Text>
             <Label>이름</Label>
-            <Text>김초이</Text>
-            <Label>소셜 로그인</Label>
-            <RiKakaoTalkFill size={30} color={'#362419'}/>
-            <Label>닉네임</Label>
-            <Input defaultValue={'마오옹'}></Input>
+            <Text>하헌진</Text>
           </Grid>
           <Title>
             비밀번호 변경
@@ -155,9 +150,9 @@ const EditUserInfo = () => {
             <Label>현재 비밀번호</Label>
             <Input placeholder="기존 비밀번호를 입력해주세요"></Input>
             <Label>새 비밀번호</Label>
-            <Input placeholder="변경할 비밀번호를 입력해주세요"></Input>
+            <Input placeholder="새 비밀번호를 입력해주세요"></Input>
             <Label>비밀번호 확인</Label>
-            <Input placeholder="변경할 비밀번호를 재입력해주세요"></Input>
+            <Input placeholder="새 비밀번호를 재입력해주세요"></Input>
           </Grid>
         </InnerWrapper>
         <Button>수정하기</Button>
@@ -168,4 +163,4 @@ const EditUserInfo = () => {
 
 }
 
-export default EditUserInfo;
+export default EditUserInfoTherapist;


### PR DESCRIPTION
- 상담사 개인정보 수정 페이지를 작성하였습니다.
- grid의 라벨 부분 column width가 커서 모바일 화면에서 두 줄로 나와 column width를 수정하였습니다
- placeholder 폰트 사이즈가 커서 모바일 화면에서는 글이 잘려나와 텍스트를 조금 수정하고 폰트 사이즈를 줄였습니다.

* 스타일 수정된 부분은 일반회원 개인정보 수정 페이지에도 모두 반영해 놓았습니다. 

![image](https://user-images.githubusercontent.com/110885007/211957384-00848462-3bfb-4af2-8f82-e9832691f95b.png)
![image](https://user-images.githubusercontent.com/110885007/211957416-bbeb506d-a8c8-47b7-b9d2-a0a1fdf0a824.png)
![image](https://user-images.githubusercontent.com/110885007/211957459-6990fa3e-b0a6-4d92-a238-4f2b61db86c3.png)
