### PR TITLE
[Design] pc화면 컨텐츠 영역 너비  조정

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -53,7 +53,7 @@ const Header = () => {
   return (
     <Contents>
       <h1>
-        <Link to='/'>LOGO TEXT</Link>
+        <Link to='/'>TEATIME</Link>
       </h1>
       <NavBar />
       {isLoggedIn ? <MyPageButton /> : <SignButtons />}

--- a/client/src/pages/ModifyBoard.tsx
+++ b/client/src/pages/ModifyBoard.tsx
@@ -29,7 +29,7 @@ const Content = styled.main`
     min-height: calc(100vh - 64px);
   }
   @media screen and (min-width: 1200px) {
-    width: 1200px;
+    width: 1000px;
     margin: 0 auto;
     padding: 90px 0 20px;
     min-height: calc(100vh - 70px);

--- a/client/src/pages/ModifyNotice.tsx
+++ b/client/src/pages/ModifyNotice.tsx
@@ -29,7 +29,7 @@ const Content = styled.main`
     min-height: calc(100vh - 64px);
   }
   @media screen and (min-width: 1200px) {
-    width: 1200px;
+    width: 1000px;
     margin: 0 auto;
     padding: 90px 0 20px;
     min-height: calc(100vh - 70px);

--- a/client/src/pages/WriteBoard.tsx
+++ b/client/src/pages/WriteBoard.tsx
@@ -29,7 +29,7 @@ const Content = styled.main`
     min-height: calc(100vh - 64px);
   }
   @media screen and (min-width: 1200px) {
-    width: 1200px;
+    width: 1000px;
     margin: 0 auto;
     padding: 90px 0 20px;
     min-height: calc(100vh - 70px);

--- a/client/src/pages/WriteNotice.tsx
+++ b/client/src/pages/WriteNotice.tsx
@@ -29,7 +29,7 @@ const Content = styled.main`
     min-height: calc(100vh - 64px);
   }
   @media screen and (min-width: 1200px) {
-    width: 1200px;
+    width: 1000px;
     margin: 0 auto;
     padding: 90px 0 20px;
     min-height: calc(100vh - 70px);

--- a/client/src/pages/community_main.tsx
+++ b/client/src/pages/community_main.tsx
@@ -17,7 +17,7 @@ const ContentWrapper = styled.div`
     min-height: calc(100vh - 64px);
   }
   @media screen and (min-width: 1200px) {
-    width: 1200px;
+    width: 1000px;
     margin: 0 auto;
     padding: 90px 0 20px;
     min-height: calc(100vh - 70px);

--- a/client/src/pages/mypage_general.tsx
+++ b/client/src/pages/mypage_general.tsx
@@ -23,7 +23,7 @@ const ContentWrapper = styled.div`
     min-height: calc(100vh - 64px);
   }
   @media screen and (min-width: 1200px) {
-    width: 1100px;
+    width: 1080px;
     margin: 0 auto;
     padding: 90px 0 20px;
     min-height: calc(100vh - 70px);

--- a/client/src/pages/program_detail.tsx
+++ b/client/src/pages/program_detail.tsx
@@ -19,7 +19,7 @@ const Contents = styled.main`
     min-height: calc(100vh - 64px);
   }
   @media screen and (min-width: 1200px) {
-    width: 1200px;
+    width: 1080px;
     margin: 0 auto;
     gap: 24px;
     padding-top: 90px;


### PR DESCRIPTION
전체적으로 pc화면일 때 컨텐츠 영역을 넓게 사용하는 페이지가 많지 않아서 기존에 1200px로 잡았던 프로그램 상세 페이지와 게시판의 컨텐츠 너비를 조정했습니다.