### PR TITLE
[Feat] 인트로페이지 연결

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -69,6 +69,7 @@ function App() {
   });
 
   const userRole = useAppSelector((state) => state.login.role);
+  const isFirst = useAppSelector((state) => state.intro.firstVisit);
 
   return (
     <div className='App'>
@@ -78,7 +79,7 @@ function App() {
         <Routes>
           <Route path='/intro' element={<Intro />} />
 
-          <Route path='/' element={<AllPrograms />} />
+          <Route path='/' element={isFirst ? <Intro /> : <AllPrograms />} />
           <Route path='/programs/:id' element={<SymptomPrograms />} />
           <Route path='/program/:id' element={<ProgramDetail />} />
           <Route path='/program/book' element={<Book />} />

--- a/client/src/pages/intro.tsx
+++ b/client/src/pages/intro.tsx
@@ -1,5 +1,8 @@
+import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import { useAppDispatch } from '../store/hooks';
+import { introActions } from '../store/intro';
 
 const OuterWrapper = styled.div`
   min-height: calc(100vh - 120px);
@@ -115,6 +118,8 @@ const MobileLogo = styled.img`
 `;
 
 const Intro = () => {
+  const dispatch = useAppDispatch();
+
   return (
     <div>
       <OuterWrapper>
@@ -127,10 +132,18 @@ const Intro = () => {
           </SubMessage>
           <MobileLogo src='green-tea.png' />
           <ButtonWrapper>
-            <Button>
+            <Button
+              onClick={() => {
+                dispatch(introActions.intro(false));
+              }}
+            >
               <Link to='/about'>잘 몰라요. 조금 더 알려주실래요?</Link>
             </Button>
-            <Button>
+            <Button
+              onClick={() => {
+                dispatch(introActions.intro(false));
+              }}
+            >
               <Link to='/'>이미 알고있어요</Link>
             </Button>
           </ButtonWrapper>

--- a/client/src/store/intro.ts
+++ b/client/src/store/intro.ts
@@ -1,0 +1,19 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  firstVisit: true,
+};
+
+const introSlice = createSlice({
+  name: 'intro',
+  initialState: initialState,
+  reducers: {
+    intro(state, action) {
+      state.firstVisit = action.payload;
+    },
+  },
+});
+
+export const introActions = introSlice.actions;
+
+export default introSlice.reducer;

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -14,17 +14,19 @@ import {
 import loginReducer from './login';
 import testReducer from './test';
 import paymentReducer from './payment';
+import introReducer from './intro';
 
 const reducers = combineReducers({
   login: loginReducer,
   test: testReducer,
   payment: paymentReducer,
+  intro: introReducer,
 });
 
 const persistConfig = {
   key: 'root',
   storage,
-  whitelist: ['login'],
+  whitelist: ['login', 'intro'],
 };
 
 const persistedReducer = persistReducer(persistConfig, reducers);


### PR DESCRIPTION
최초 접속 시(로컬스토리지 persist에 firstVisit 값이 true) root(/) 경로에서 인트로페이지를 보여주고,
인트로페이지에서 어떤 버튼(모든 버튼)을 누르면 firstVisit을 false로 변경해서 root(/) 경로에서 전체 페이지를 보여줍니다.
<img width="1201" alt="스크린샷 2023-01-29 오후 8 22 10" src="https://user-images.githubusercontent.com/110894240/215322852-b5112bb9-74de-4a8d-adfa-b25275842925.png">
<img width="1199" alt="스크린샷 2023-01-29 오후 8 23 11" src="https://user-images.githubusercontent.com/110894240/215322855-8c4c6131-547e-472b-b169-0594c0badbd0.png">
